### PR TITLE
plugins/if: include "Interface" to graph_title for better grouping

### DIFF
--- a/plugins/if_
+++ b/plugins/if_
@@ -1,7 +1,7 @@
 config_if() {
   INTERFACE=$1
   echo "graph_order down up"
-  echo "graph_title $INTERFACE traffic"
+  echo "graph_title Interface $INTERFACE traffic"
   echo "graph_args --base 1000"
   echo "graph_vlabel bits in (-) / out (+) per \${graph_period}"
   echo "graph_category network"

--- a/plugins/if_err_
+++ b/plugins/if_err_
@@ -1,7 +1,7 @@
 config_if_err() {
   INTERFACE=$1
   echo "graph_order rcvd trans"
-  echo "graph_title $INTERFACE errors"
+  echo "graph_title Interface $INTERFACE errors"
   echo "graph_args --base 1000"
   echo "graph_vlabel packets in (-) / out (+) per \${graph_period}"
   echo "graph_category network"


### PR DESCRIPTION
Nowadays network interfaces have names like docker0, team0, ip_vti0, eno,
wlp61s0 and so on. Including word "Interface" in beginning of
graph_title groups these graphs together in web interface, not randomly
before/after other network-graphs (ipconntrack, firewall, ...).

See commit 70711831c44 in munin repository for similar change.