### PR TITLE
muninlite: do not crash if empty line is received

### DIFF
--- a/muninlite.in
+++ b/muninlite.in
@@ -119,7 +119,7 @@ do
   arg1=$(echo "$arg1" | xargs)
   if ! echo "$FUNCTIONS" | grep -qwF "$arg0"; then
     echo "# Unknown command. Try $(echo "$FUNCTIONS" | sed -e 's/\( [[:alpha:]]\{1,\}\)/,\1/g' -e 's/,\( [[:alpha:]]\{1,\}\)$/ or\1/')"
-  elif [ ! -z "$arg0" ]; then
+  elif [ -n "$arg0" ]; then
     "do_$arg0" "$arg1"
   fi
 done

--- a/muninlite.in
+++ b/muninlite.in
@@ -119,7 +119,7 @@ do
   arg1=$(echo "$arg1" | xargs)
   if ! echo "$FUNCTIONS" | grep -qwF "$arg0"; then
     echo "# Unknown command. Try $(echo "$FUNCTIONS" | sed -e 's/\( [[:alpha:]]\{1,\}\)/,\1/g' -e 's/,\( [[:alpha:]]\{1,\}\)$/ or\1/')"
-  else
+  elif [ ! -z "$arg0" ]; then
     "do_$arg0" "$arg1"
   fi
 done


### PR DESCRIPTION
Trivial fix for following error:

root@naru:~# echo "" | ./muninlite
./muninlite: line 696: do_: not found
root@naru:~#