### PR TITLE
df: fix "config" vs "fetch" mismatches

### DIFF
--- a/muninlite.conf
+++ b/muninlite.conf
@@ -1,2 +1,3 @@
 # the following variables are added to the top of the assembled muninlite script
 NTP_PEER="pool.ntp.org"
+DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"

--- a/plugins/df
+++ b/plugins/df
@@ -1,14 +1,13 @@
 config_df() {
-  IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
   echo "graph_title Filesystem usage (in %)
 graph_args --upper-limit 100 -l 0
 graph_vlabel %
 graph_category disk
 graph_info This graph shows disk usage on the machine."
-  for PART in $(df -PT | grep '^/' | grep -vwE "$IGNORE_FILESYSTEM_REGEX" | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
+  for PART in $(df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
   do
     PINFO=$(df -P "$PART" | tail -1);
-    PNAME=$(echo "$PINFO" | cut -d " " -f 1 | sed 's/\//_/g')
+    PNAME=$(clean_fieldname $(echo "$PINFO" | cut -d " " -f 1))
     echo "$PNAME.label $PART"
     echo "$PNAME.info $PNAME -> $PART"
     echo "$PNAME.warning 92"
@@ -16,10 +15,10 @@ graph_info This graph shows disk usage on the machine."
   done
 }
 fetch_df() {
-  for PART in $(df -P | grep '^/' | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
+  for PART in $(df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
   do
     PINFO=$(df -P "$PART" | tail -1);
-    PNAME=$(echo "$PINFO" | cut -d " " -f 1 | sed 's/[\/.-]/_/g')
+    PNAME=$(clean_fieldname $(echo "$PINFO" | cut -d " " -f 1))
     echo "$PNAME.value" "$(echo "$PINFO" | sed -e 's/\%//g' -e 's/  */ /g' | cut -d " " -f 5)"
   done
 }

--- a/plugins/df
+++ b/plugins/df
@@ -7,7 +7,7 @@ graph_info This graph shows disk usage on the machine."
   for PART in $(df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
   do
     PINFO=$(df -P "$PART" | tail -1);
-    PNAME=$(clean_fieldname $(echo "$PINFO" | cut -d " " -f 1))
+    PNAME=$(clean_fieldname "$(echo "$PINFO" | cut -d " " -f 1)")
     echo "$PNAME.label $PART"
     echo "$PNAME.info $PNAME -> $PART"
     echo "$PNAME.warning 92"
@@ -18,7 +18,7 @@ fetch_df() {
   for PART in $(df -PT | grep '^/' | grep -vwE "$DF_IGNORE_FILESYSTEM_REGEX" | sed '/\/[a-z0-9]*$/!d;s/.* \([a-z0-9\/]\{1,\}\)$/\1/g')
   do
     PINFO=$(df -P "$PART" | tail -1);
-    PNAME=$(clean_fieldname $(echo "$PINFO" | cut -d " " -f 1))
+    PNAME=$(clean_fieldname "$(echo "$PINFO" | cut -d " " -f 1)")
     echo "$PNAME.value" "$(echo "$PINFO" | sed -e 's/\%//g' -e 's/  */ /g' | cut -d " " -f 5)"
   done
 }


### PR DESCRIPTION
Two fixes:
1) Use same regexp to skip df partitions in "config" and "fetch".
2) Use same function (was two different sed) to cleanup partition name.

This fixes bug #5.