### PR TITLE
muninlite: add support for minimal runtime configuration file

### DIFF
--- a/muninlite.in
+++ b/muninlite.in
@@ -16,6 +16,9 @@ set -eu
 
 @@CONF@@
 
+# Name of runtime configuration file
+CONFIG_FILE=/etc/munin/muninlite.conf
+
 # if plugindir_ is present in $PLUGINS, executables (scripts, binaries) in the specified path
 # and matching the pattern will be scanned and operated as plugins
 PLUGIN_DIRECTORY=/etc/munin/plugins
@@ -69,6 +72,7 @@ do_quit() {
 }
 
 # ===== Runtime config =====
+[ -f ${CONFIG_FILE} ] && . ${CONFIG_FILE}
 RES=""
 for PLUG in $PLUGINS; do
   case "$PLUG" in

--- a/muninlite.in
+++ b/muninlite.in
@@ -72,6 +72,7 @@ do_quit() {
 }
 
 # ===== Runtime config =====
+# shellcheck source=/dev/null
 [ -f ${CONFIG_FILE} ] && . ${CONFIG_FILE}
 RES=""
 for PLUG in $PLUGINS; do


### PR DESCRIPTION
It's executed as shell script. For example, you can remove unwanted
plugin by adding following line to /etc/munin/muninlite.conf:

PLUGINS=${PLUGINS/ swap/}

It could also be used to add more plugins (with runtime on/off detection!),
although pluginsdir is the preferred way to do it.

It can also be used to override other hardcoded settings, like NTP_PEER or
DF_IGNORE_FILESYSTEM_REGEX.