### PR TITLE
irqstats: fix iqrstats on Raspberry Pi (partial revert for 5190244c)

### DIFF
--- a/plugins/irqstats
+++ b/plugins/irqstats
@@ -29,7 +29,9 @@ fetch_irqstats() {
     VALUE=0
     for VAL in $VALS;
     do
-      VALUE=$((VALUE + $VAL))
+      if [ "$VAL" -eq "$VAL" ] 2> /dev/null; then
+        VALUE=$((VALUE + VAL))
+      fi
     done
     echo "i$ID.value $VALUE"
   done

--- a/plugins/irqstats
+++ b/plugins/irqstats
@@ -29,7 +29,7 @@ fetch_irqstats() {
     VALUE=0
     for VAL in $VALS;
     do
-      VALUE=$((VALUE + VAL))
+      VALUE=$((VALUE + $VAL))
     done
     echo "i$ID.value $VALUE"
   done


### PR DESCRIPTION
Raspberry Pi has line "FIQ:              usb_fiq" in /proc/interrupts.
"VALUE=$((VALUE + VAL))" results "Illegal number" in dash (Raspberry Pi)
"VALUE=$((VALUE + $VAL))" works in dash, bash and busybox (OpenWrt).