### PR TITLE
Allow customizing the list of monitored network interfaces

### DIFF
--- a/muninlite.conf
+++ b/muninlite.conf
@@ -3,4 +3,4 @@ NTP_PEER="pool.ntp.org"
 DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
 
 #INTERFACE_NAMES_OVERRIDE="eth0"
-#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -P '^(eth|wlan|en)')"
+#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -E '^(eth|wlan|en)')"

--- a/muninlite.conf
+++ b/muninlite.conf
@@ -1,3 +1,6 @@
 # the following variables are added to the top of the assembled muninlite script
 NTP_PEER="pool.ntp.org"
 DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
+
+#INTERFACE_NAMES_OVERRIDE="eth0"
+#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -P '^(eth|wlan|en)')"

--- a/muninlite.conf
+++ b/muninlite.conf
@@ -3,4 +3,3 @@ NTP_PEER="pool.ntp.org"
 DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
 
 #INTERFACE_NAMES_OVERRIDE="eth0"
-#INTERFACE_NAMES_OVERRIDE="$(sed 's/^ *//; s/:.*$//; / /d' /proc/net/dev | grep -E '^(eth|wlan|en)')"

--- a/muninlite.in
+++ b/muninlite.in
@@ -78,7 +78,7 @@ RES=""
 for PLUG in $PLUGINS; do
   case "$PLUG" in
     if_|if_err_)
-      if [ -z "$INTERFACE_NAMES_OVERRIDE" ]; then
+      if [ -z "${INTERFACE_NAMES_OVERRIDE:-}" ]; then
         interface_names=$(sed 's/^ *//; s/:.*$//; / /d; /^lo$/d' /proc/net/dev)
       else
         interface_names="$INTERFACE_NAMES_OVERRIDE"

--- a/muninlite.in
+++ b/muninlite.in
@@ -78,7 +78,11 @@ RES=""
 for PLUG in $PLUGINS; do
   case "$PLUG" in
     if_|if_err_)
-      interface_names=$(sed 's/^ *//; s/:.*$//; / /d; /^lo$/d' /proc/net/dev)
+      if [ -z "$INTERFACE_NAMES_OVERRIDE" ]; then
+        interface_names=$(sed 's/^ *//; s/:.*$//; / /d; /^lo$/d' /proc/net/dev)
+      else
+        interface_names="$INTERFACE_NAMES_OVERRIDE"
+      fi
       for INTER in $interface_names; do
         INTERRES=$(echo "$INTER" | sed -e 's/\./VLAN/' -e 's/\-/_/g')
         RES="$RES ${PLUG}${INTERRES}"


### PR DESCRIPTION
This is a simple way to customize the selection of network interfaces. If `INTERFACE_NAMES_OVERRIDE` is set in `muninlite.conf`, that list is used instead of auto-detection. As `muninlite.conf` itself is also a script, it is even possible to write a custom command.

This feature is helpful in environments with virtual machines or containers, like docker or lxc where there are lots of `br-*`, `veth*`, `lxcbr*` etc interfaces where monitoring doesn't make much sense. I didn't find a way to reliably filter physical interfaces.