### PR TITLE
irqstat: Use logarithmic scale.

### DIFF
--- a/plugins/irqstats
+++ b/plugins/irqstats
@@ -1,6 +1,6 @@
 config_irqstats() {
   echo "graph_title Individual interrupts
-graph_args --base 1000 -l 0
+graph_args --base 1000 -o
 graph_vlabel interrupts / \${graph_period}
 graph_category system"
   CPUS=$(grep 'CPU[0-9]' /proc/interrupts | wc -w)


### PR DESCRIPTION
This makes the graph a bit more readable when different interrupts have widely different frequencies.

It's also how the "heavy" plugin does it. See e.g.:

https://github.com/munin-monitoring/munin/blob/091c8e612c77e99718bc4dc282a0168b3cafa7a5/plugins/node.d.linux/irqstats#L159