### PR TITLE
Add timeout option to prevent the process from blocking #21

### DIFF
--- a/muninlite.conf
+++ b/muninlite.conf
@@ -3,3 +3,9 @@ NTP_PEER="pool.ntp.org"
 DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
 
 #INTERFACE_NAMES_OVERRIDE="eth0"
+
+# Timeout seconds for waiting for input in the main function.
+## If you find a large number of muninlite processes associate with idle connections, consider setting this value. 
+## Please note that this option may not be supported by your current shell.
+# Default:0 (disable)
+TIMEOUT_SEC=0

--- a/muninlite.in
+++ b/muninlite.in
@@ -126,7 +126,7 @@ PLUGINS=$(echo "$RES" | xargs -r -n 1 echo | sort | xargs echo)
 
 # build timeout option if timeout parameter is present. See TIMEOUT_SEC in muninlite.conf
 TIMEOUT_OPT=""
-if [ $TIMEOUT_SEC -gt 0 ]; then TIMEOUT_OPT="-t $TIMEOUT_SEC"; fi
+if [ "$TIMEOUT_SEC" -gt 0 ]; then TIMEOUT_OPT="-t $TIMEOUT_SEC"; fi
 
 # ===== MAIN LOOP =====
 FUNCTIONS="list nodes config fetch version quit"

--- a/muninlite.in
+++ b/muninlite.in
@@ -26,6 +26,7 @@ PLUGINPATTERN="*"
 
 # Remove unwanted plugins from this list
 PLUGINS="@@PLUGINS@@"
+
 # ===== LIB FUNCTIONS =====
 clean_fieldname() {
   echo "$@" | sed -e 's/^[^A-Za-z_]/_/' -e 's/[^A-Za-z0-9_]/_/g'
@@ -123,11 +124,15 @@ done
 # sort plugin names and remove surrounding whitespace
 PLUGINS=$(echo "$RES" | xargs -r -n 1 echo | sort | xargs echo)
 
+# build timeout option if timeout parameter is present. See TIMEOUT_SEC in muninlite.conf
+TIMEOUT_OPT=""
+if [ $TIMEOUT_SEC -gt 0 ]; then TIMEOUT_OPT="-t $TIMEOUT_SEC"; fi
+
 # ===== MAIN LOOP =====
 FUNCTIONS="list nodes config fetch version quit"
 HOSTNAME=$( { hostname -f || hostname || cat /proc/sys/kernel/hostname || echo "unknown"; } 2>/dev/null )
 echo "# munin node at $HOSTNAME"
-while read -r arg0 arg1
+while read $TIMEOUT_OPT -r arg0 arg1
 do
   arg0=$(printf '%s\n' "$arg0" | xargs)
   arg1=$(printf '%s\n' "$arg1" | xargs)


### PR DESCRIPTION
> This PR is related to #21 . 

Sorry for the rough editing. 
Added a parameter to muninlite.conf and disabled it by default^. 
Added a line to set the timeout based on this parameter in muninlite.in. 
Actually, I was wondering if this change is necessary, because ^not all shells support timeout settings. 
I did a simple test and got the following results.
- [x] bash
- [x] ash
- [ ] tcsh
- [ ] zsh

Please consider it carefully. Thanks!