### PR TITLE
df: ignore erofs disks

### DIFF
--- a/muninlite.conf
+++ b/muninlite.conf
@@ -1,6 +1,6 @@
 # the following variables are added to the top of the assembled muninlite script
 NTP_PEER="pool.ntp.org"
-DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|ramfs|debugfs|cgroup_root|devtmpfs)"
+DF_IGNORE_FILESYSTEM_REGEX="(none|unknown|rootfs|iso9660|squashfs|udf|romfs|erofs|ramfs|debugfs|cgroup_root|devtmpfs)"
 
 #INTERFACE_NAMES_OVERRIDE="eth0"
 


### PR DESCRIPTION
erofs is another read only filesystem

[1] https://docs.kernel.org/filesystems/erofs.html